### PR TITLE
Validation: null-safe normalization for names (+ API guard test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,10 @@ curl -i -X POST http://127.0.0.1:8000/api/applications -H "Content-Type: applica
 ```
 
 You should also see one JSON access log line per request in the server terminal.
+
+## Validation & Normalization
+
+- Names: `first_name` and `last_name` are trimmed (leading/trailing whitespace removed).
+- `middle_name` may be null or omitted. If provided as a string, it is trimmed; if it becomes empty after trimming, it is stored as null.
+- Email must be unique. Duplicate emails return a `400` with a JSON validation error on `applicant.email`.
+- Other field validations remain as-is.

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+
+class ApplicationCreateNormalizationTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_create_with_null_middle_name_returns_201(self):
+        payload = {
+            "applicant": {
+                "first_name": "  Asha  ",
+                "middle_name": None,
+                "last_name": "  Mehta ",
+                "email": "asha.norm@example.com",
+                "phone": "+1-415-555-1200",
+                "annual_income": "125000.00",
+                "employment_status": "SALARIED",
+                "city": "San Francisco",
+                "state": "CA",
+                "country": "US",
+                "postal_code": "94107",
+            },
+            "product": "Platinum",
+        }
+        resp = self.client.post("/api/applications", data=payload, format="json")
+        self.assertEqual(resp.status_code, 201, resp.content)
+        self.assertIn("id", resp.data)
+
+


### PR DESCRIPTION
**Why**Ensure consistent input hygiene and guard against common None/blank pitfalls, especially for middle\_name. This becomes the explicit canary before the upcoming refactor.

**What**

*   Trim first\_name/last\_name.
    
*   middle\_name: trim when string; whitespace → null; preserve null if provided.
    
*   Focused API test: POST with middle\_name: null → **201**.
    
*   Docs: brief normalization rules and rationale.
    

**Acceptance**

*   middle\_name: null → 201; whitespace-only → stored as null.
    
*   Non-null middle name still 201.
    
*   Test suite green.
    

**Risk / Rollback**Low; narrow serializer change. Revertible.

**Future**Keep this test to detect regressions caused by refactors touching serializer logic.